### PR TITLE
15 implement anti dump feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ The list of main features:<br>
 <b>e.</b> any buy/sell operations on uniswap will cut tokens by sell/buy taxes<br>
 <b>f.</b> owner(and managers) can add any person to managers role, but can't remove from it<br>
 
+## Common features
+####<b>to be described</b><br>
+&nbsp;&nbsp;<b>1.</b> Params (eg PreventPanic)<br>
+&nbsp;&nbsp;<b>2.</b>Presale<br>
+&nbsp;&nbsp;<b>3.</b>AddInitialLiquidity<br>
+&nbsp;&nbsp;<b>4.</b>GradualTaxes<br>
+&nbsp;&nbsp;<b>5.</b>Claiming and RestrictClaiming<br>
+&nbsp;&nbsp;<b>6.</b>AddLiquidity<br>

--- a/contracts/TradedToken.sol
+++ b/contracts/TradedToken.sol
@@ -161,7 +161,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
     error CanNotBeZero();
     error InputAmountCanNotBeZero();
     error InsufficientAmount();
-    error TaxCanNotBeMoreThen(uint64 fraction);
+    error TaxCanNotBeMoreThan(uint64 fraction);
     error PriceDropTooBig();
     error OwnerAndManagersOnly();
     error ManagersOnly();
@@ -173,7 +173,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
     error PriceHasBecomeALowerThanMinClaimPrice();
     error ClaimsEnabledTimeAlreadySetup();
     error ClaimTooFast(uint256 untilTime);
-    error ShouldBeMoreThenMinClaimPrice();
+    error ShouldBeMoreThanMinClaimPrice();
     error MinClaimPriceGrowTooFast();
     error NotAuthorized();
     error AntiDumpFeature();
@@ -290,7 +290,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
         }
        
         if (buyTaxMax > FRACTION || sellTaxMax > FRACTION) {
-            revert TaxCanNotBeMoreThen(FRACTION);
+            revert TaxCanNotBeMoreThan(FRACTION);
         }
         
 
@@ -406,7 +406,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
      */
     function setBuyTax(uint16 newTax) external onlyOwner {
         if (newTax > buyTaxMax) {
-            revert TaxCanNotBeMoreThen(buyTaxMax);
+            revert TaxCanNotBeMoreThan(buyTaxMax);
         }
         taxesInfo.fromBuyTax = taxesInfo.toBuyTax;
         taxesInfo.toBuyTax = newTax;
@@ -422,7 +422,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
      */
     function setSellTax(uint16 newTax) external onlyOwner {
         if (newTax > sellTaxMax) {
-            revert TaxCanNotBeMoreThen(sellTaxMax);
+            revert TaxCanNotBeMoreThan(sellTaxMax);
         }
         taxesInfo.fromSellTax = taxesInfo.toSellTax;
         taxesInfo.toSellTax = newTax;
@@ -491,7 +491,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
         FixedPoint.uq112x112 memory minClaimPriceFraction       = FixedPoint.fraction(minClaimPrice.numerator, minClaimPrice.denominator);
         FixedPoint.uq112x112 memory minClaimPriceGrowFraction   = FixedPoint.fraction(minClaimPriceGrow.numerator, minClaimPriceGrow.denominator);
         if (newMinimumPriceFraction._x <= minClaimPriceFraction._x) {
-            revert ShouldBeMoreThenMinClaimPrice();
+            revert ShouldBeMoreThanMinClaimPrice();
         }
         if (
             newMinimumPriceFraction._x - minClaimPriceFraction._x > minClaimPriceGrowFraction._x ||

--- a/contracts/TradedToken.sol
+++ b/contracts/TradedToken.sol
@@ -73,7 +73,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
 
     struct RateLimit {
         uint32 duration; // for time ranges, 32 bits are enough, can also define constants like DAY, WEEK, MONTH
-        uint32 fraction; // out of 100,000
+        uint32 fraction; // out of 10,000
     }
     mapping (address => RateLimit) public rateLimit;
 

--- a/contracts/TradedToken.sol
+++ b/contracts/TradedToken.sol
@@ -117,7 +117,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
      * @custom:shortd uniswap v2 pair
      * @notice uniswap v2 pair
      */
-    address public immutable uniswapV2Pair;
+    address internal immutable uniswapV2Pair;
 
     address internal uniswapRouter;
     address internal uniswapRouterFactory;

--- a/contracts/TradedToken.sol
+++ b/contracts/TradedToken.sol
@@ -18,6 +18,8 @@ import "./libs/FixedPoint.sol";
 import "./minimums/libs/MinimumsLib.sol";
 import "./helpers/Liquidity.sol";
 
+import "./interfaces/IFund.sol";
+
 //import "hardhat/console.sol";
 
 contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, ReentrancyGuard {
@@ -722,6 +724,26 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
             return taxesInfo.toSellTax;
         }
     }
+
+    function presaleAdd(
+        address account,
+        uint256 amount
+    )
+        public
+        initialLiquidityRequired
+        onlyOwner
+    {
+        _mint(address, amount, "", "");
+        emit Presale(account, amount);
+    }
+
+    function presaleBurnRemaining(contract) public {
+        uint64 endTime = IPresale(contract).endTime();
+        if (block.timestamp > endTime) {
+            _burn(contract, balanceOf(contract), "", "");
+        }
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // internal section ////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/TradedToken.sol
+++ b/contracts/TradedToken.sol
@@ -20,7 +20,7 @@ import "./helpers/Liquidity.sol";
 
 import "./interfaces/IPresale.sol";
 
-//import "hardhat/console.sol";
+import "hardhat/console.sol";
 
 contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, ReentrancyGuard {
     using FixedPoint for *;
@@ -117,7 +117,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
      * @custom:shortd uniswap v2 pair
      * @notice uniswap v2 pair
      */
-    address internal immutable uniswapV2Pair;
+    address public immutable uniswapV2Pair;
 
     address internal uniswapRouter;
     address internal uniswapRouterFactory;
@@ -585,7 +585,10 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
         address recipient,
         uint256 amount
     ) public virtual override returns (bool) {
-        //amount = preventPanic(holder, recipient, amount);
+console.log("==transferFrom==");   
+console.log("[!]amount = ", amount);
+        amount = preventPanic(holder, recipient, amount);
+console.log("[!]amount = ", amount);
         if(uniswapV2Pair == recipient && holder != address(internalLiquidity)) {
             
             uint256 taxAmount = (amount * sellTax()) / FRACTION;
@@ -605,10 +608,13 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
         internal 
         returns(uint256 adjustedAmount)
     {
-        
+console.log("==preventPanic==");        
+console.log("holder     = ", holder);
+console.log("recipient  = ", recipient);
+console.log("amount     = ", amount);
         if (
-            holder == address(internalLiquidity) ||
-            recipient == address(internalLiquidity) ||
+            // holder == address(internalLiquidity) ||
+            // recipient == address(internalLiquidity) ||
             panicSellRateLimit[recipient].fraction == 0 ||
             panicSellRateLimit[recipient].duration == 0
 
@@ -620,6 +626,10 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
         
         uint256 currentBalance = balanceOf(holder);
         uint256 max = currentBalance * panicSellRateLimit[recipient].fraction / FRACTION;
+        
+console.log("holder         = ", holder);
+console.log("currentBalance = ", currentBalance);
+console.log("max            = ", max);
         uint32 duration = panicSellRateLimit[recipient].duration;
         duration = (duration == 0) ? 1 : duration; // make no sense if duration eq 0      
 
@@ -652,6 +662,7 @@ contract TradedToken is Ownable, IERC777Recipient, IERC777Sender, ERC777, Reentr
         
         //address from = _msgSender();
         address msgSender = _msgSender();
+        console.log("==transfer==");   
         amount = preventPanic(msgSender, recipient, amount);
 
         // inject into transfer and burn tax from sender

--- a/contracts/interfaces/IPresale.sol
+++ b/contracts/interfaces/IPresale.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IPresale {
+    function endTime() external view returns (uint64);
+}
+

--- a/contracts/mocks/TradedTokenContractMock.sol
+++ b/contracts/mocks/TradedTokenContractMock.sol
@@ -52,23 +52,14 @@ contract TradedTokenMock is TradedToken {
         return _maxAddLiquidity();
     }
 
-    function getTradedAveragePrice(
-    ) 
-        public
-        view
-        returns(FixedPoint.uq112x112 memory)
-    {
-        return _tradedAveragePrice();
-    }
-
-    function uniswapReservesSimple(
-    ) 
-        public 
-        view 
-        returns(uint256, uint256, uint256)
-    {
-        return _uniswapReserves();
-    }
+    // function getTradedAveragePrice(
+    // ) 
+    //     public
+    //     view
+    //     returns(FixedPoint.uq112x112 memory)
+    // {
+    //     return _tradedAveragePrice();
+    // }
 
     function totalInfo(
 
@@ -103,40 +94,5 @@ contract TradedTokenMock is TradedToken {
         taxesInfo.sellTaxGradual = taxesInfoInit.sellTaxGradual;
  
     }
-    // function uniswapPrices(
-    // ) 
-    //     //internal  
-    //     public
-    //     view 
-    //     // reserveTraded, reserveReserved, priceTraded, priceReserved, averagePriceTraded, averagePriceReserved, blockTimestamp
-    //     returns(uint256, uint256, uint256, uint256, uint256, uint256, uint32)
-    // {
-    //     // reserveTraded    reserveReserved
-    //     (uint256 reserve0, uint256 reserve1, uint32 blockTimestamp) = _uniswapPrices();
-        
-    //     //if (IUniswapV2Pair(uniswapV2Pair).token0() == tradedToken) {
-    //         return(
-    //             reserve0, 
-    //             reserve1, 
-    //             FRACTION * reserve0 / reserve1,
-    //             FRACTION * reserve1 / reserve0,
-    //             pairObservation.price0Average.decode(),
-    //             pairObservation.price1Average.decode(),
-    //             blockTimestamp
-    //         );
-    //     // } else {
-    //     //     return(
-    //     //         reserve1, 
-    //     //         reserve0, 
-    //     //         FRACTION * reserve1 / reserve0,
-    //     //         FRACTION * reserve0 / reserve1,
-    //     //         FRACTION * price1Average.decode(),
-    //     //         FRACTION * price0Average.decode(),
-    //     //         blockTimestamp
-    //     //     );
-    //     // }
-
-    // }
-
-
+  
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -26,7 +26,7 @@ const mumbaiURL = `https://matic-mumbai.chainstacklabs.com`;
 module.exports = {
   networks: {
     hardhat: {
-      allowUnlimitedContractSize: false,
+      allowUnlimitedContractSize: true,
       forking: {
         url: mainnetURL,
         //blockNumber: 13539017

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -112,7 +112,7 @@ module.exports = {
           settings: {
             optimizer: {
               enabled: true,
-              runs: 200,
+              runs: 10,
             },
             metadata: {
               // do not include the metadata hash, since this is machine dependent

--- a/test/test.js
+++ b/test/test.js
@@ -387,7 +387,6 @@ describe("TradedTokenInstance", function () {
                     const bobTokensAfterTransfer = await mainInstance.balanceOf(bob.address);
                     const aliceTokensAfterTransfer = await mainInstance.balanceOf(alice.address);
 
-                    console.log("bobTokensBefore            = ", bobTokensBefore.toString());
 // console.log("bobTokensAfterClaim        = ", bobTokensAfterClaim.toString());
 // console.log("bobTokensAfterTransfer     = ", bobTokensAfterTransfer.toString());
 // console.log(" -------------------------------- ");
@@ -398,9 +397,37 @@ describe("TradedTokenInstance", function () {
                     expect(bobTokensAfterClaim.sub(bobTokensAfterClaim.mul(RateForAlice).div(FRACTION))).to.be.eq(aliceTokensAfterTransfer);
 
                     // try to send all that left
-                    await expect(
-                        mainInstance.connect(bob).transfer(alice.address, bobTokensAfterTransfer)
-                    ).to.be.revertedWith("PanicSellRateExceeded()");
+                    let tx = await mainInstance.connect(bob).transfer(alice.address, bobTokensAfterTransfer)
+                    const bobTokensAfterTransfer2 = await mainInstance.balanceOf(bob.address);
+                    const aliceTokensAfterTransfer2 = await mainInstance.balanceOf(alice.address);
+                    let rc = await tx.wait();
+                        
+                    // here fast and stupid way to find event PanicSellRateExceeded that cann't decoded if happens in external contract
+                    let arr2compare = [
+                        ethers.utils.id("PanicSellRateExceeded(address,address,uint256)"), // keccak256
+                        '0x'+(bob.address.replace('0x','')).padStart(64, '0'),
+                        '0x'+(alice.address.replace('0x','')).padStart(64, '0')
+                    ]
+                    let event = rc.events.find(event => JSON.stringify(JSON.stringify(event.topics)).toLowerCase() === JSON.stringify(JSON.stringify(arr2compare)).toLowerCase());
+                    let eventExists = (typeof(event) !== 'undefined') ? true : false;
+                    expect(eventExists).to.be.eq(true);
+                    if (eventExists) {
+                        // address: '0x2d13826359803522cCe7a4Cfa2c1b582303DD0B4',
+                        // topics: [
+                        //     '0xda8c6cfc61f9766da27a11e69038df366444016f44f525a2907f393407bfc6c3',
+                        //     '0x00000000000000000000000090f79bf6eb2c4f870365e785982e1f101e93b906',
+                        //     '0x0000000000000000000000009b7889734ac75060202410362212d365e9ee1ef5'
+                        // ],
+                        expect(event.address).to.be.eq(mainInstance.address);
+                        expect(ethers.utils.getAddress( event.topics[1].replace('000000000000000000000000','') )).to.be.eq(bob.address);
+                        expect(ethers.utils.getAddress( event.topics[2].replace('000000000000000000000000','') )).to.be.eq(alice.address);
+
+                        // we will adjust value in panic situation from amount to 5
+                        // so transaction didn't revert but emitted event "PanicSellRateExceeded"
+
+                        expect(bobTokensAfterTransfer.sub(5)).to.be.eq(bobTokensAfterTransfer2);
+                        expect(aliceTokensAfterTransfer.add(5)).to.be.eq(aliceTokensAfterTransfer2);
+                    }
 
                     // pass time to clear bucket
                     await network.provider.send("evm_increaseTime", [DurationForAlice+50]);
@@ -413,6 +440,8 @@ describe("TradedTokenInstance", function () {
 
                     const bobTokensAfterTransferAndTimePassed = await mainInstance.balanceOf(bob.address);
                     const aliceTokensAfterTransferAndTimePassed = await mainInstance.balanceOf(alice.address);
+                    
+                    //----------------------
 
                     // console.log("bobTokensBeforeTransferAndTimePassed   = ", bobTokensBeforeTransferAndTimePassed.toString());
                     // console.log("bobTokensAfterTransferAndTimePassed    = ", bobTokensAfterTransferAndTimePassed.toString());
@@ -420,9 +449,12 @@ describe("TradedTokenInstance", function () {
                     // console.log("aliceTokensBeforeTransferAndTimePassed = ", aliceTokensBeforeTransferAndTimePassed.toString());
                     // console.log("aliceTokensAfterTransferAndTimePassed  = ", aliceTokensAfterTransferAndTimePassed.toString());
                     
-                    expect(bobTokensBeforeTransferAndTimePassed.mul(RateForAlice).div(FRACTION)).to.be.eq(bobTokensAfterTransferAndTimePassed);
-                    expect(bobTokensAfterTransfer.add(bobTokensBeforeTransferAndTimePassed.sub(bobTokensBeforeTransferAndTimePassed.mul(RateForAlice).div(FRACTION)))).to.be.eq(aliceTokensAfterTransferAndTimePassed);
+                    expect(bobTokensBeforeTransferAndTimePassed.mul(RateForAlice).div(FRACTION).add(ONE)).to.be.eq(bobTokensAfterTransferAndTimePassed);
+                    expect(aliceTokensBeforeTransferAndTimePassed.add(bobTokensBeforeTransferAndTimePassed.sub(ONE).sub(bobTokensBeforeTransferAndTimePassed.mul(RateForAlice).div(FRACTION)))).to.be.eq(aliceTokensAfterTransferAndTimePassed);
 
+
+
+                        
                 }); 
 
                 it("shouldnt locked up tokens if owner claim to himself", async() => {
@@ -870,40 +902,80 @@ describe("TradedTokenInstance", function () {
                         expect(await erc20ReservedToken.balanceOf(internalLiquidityAddress)).to.be.lt(TEN);
                     });
 
-                    it.only("should preventPanic", async() => {
+                    it("should preventPanic", async() => {
+
                         const uniswapV2Pair = await mainInstance.uniswapV2Pair();
-console.log("uniswapV2Pair          = ", uniswapV2Pair);
-console.log("uniswapRouterInstance  = ", uniswapRouterInstance.address);
-console.log("mainInstance           = ", mainInstance.address);
-console.log("erc20ReservedToken     = ", erc20ReservedToken.address);
-console.log("bob.address            = ", bob.address);
+
                         const DurationForUniswap = 24*60*60; // day
-                        const RateForUniswap = 1000; // 10%
+                        const RateForUniswap = 5000; // 50%
                         await mainInstance.connect(owner).setRateLimit(uniswapV2Pair, [DurationForUniswap, RateForUniswap])
 
                         const InitialSendFunds = ONE_ETH;
 
-                        await mainInstance.connect(owner)["claim(uint256,address)"](InitialSendFunds, bob.address);
-                        
-                        await mainInstance.connect(bob).approve(uniswapRouterInstance.address, InitialSendFunds);
+                        await mainInstance.connect(owner)["claim(uint256,address)"](InitialSendFunds, charlie.address);
+                        await mainInstance.connect(charlie).approve(uniswapRouterInstance.address, InitialSendFunds.div(2));
                         let ts = await time.latest();
                         let timeUntil = parseInt(ts)+parseInt(lockupIntervalAmount*DAY);
-console.log("balance[uniswapV2Pair] = ", await mainInstance.balanceOf(uniswapV2Pair));
-                        await uniswapRouterInstance.connect(bob).swapExactTokensForTokens(
-                            ONE_ETH.div(2), //uint amountIn,
+
+                        //swapExactTokensForTokensSupportingFeeOnTransferTokens
+                        //swapExactTokensForTokens
+                        await uniswapRouterInstance.connect(charlie).swapExactTokensForTokensSupportingFeeOnTransferTokens(
+                            InitialSendFunds.div(2), //uint amountIn,
                             0, //uint amountOutMin,
                             [mainInstance.address, erc20ReservedToken.address], //address[] calldata path,
-                            bob.address, //address to,
+                            charlie.address, //address to,
                             timeUntil //uint deadline   
 
                         );
-console.log("balance[uniswapV2Pair] = ", await mainInstance.balanceOf(uniswapV2Pair));
-                    // // try to send all that left
-                    // await expect(
-                    //     mainInstance.connect(bob).transfer(alice.address, bobTokensAfterTransfer)
-                    // ).to.be.revertedWith("PanicSellRateExceeded()");
+                        // // try to send all that left
+                        await mainInstance.connect(charlie).approve(uniswapRouterInstance.address, InitialSendFunds.div(2));
 
-                }); 
+                        //PanicSellRateExceeded()
+                        let charlieBalanceBeforePanic = await mainInstance.balanceOf(charlie.address);
+                        let charlieBalanceReservedBeforePanic = await erc20ReservedToken.balanceOf(charlie.address);
+                        let tx = await uniswapRouterInstance.connect(charlie).swapExactTokensForTokensSupportingFeeOnTransferTokens(
+                                InitialSendFunds.div(2), //uint amountIn,
+                                0, //uint amountOutMin,
+                                [mainInstance.address, erc20ReservedToken.address], //address[] calldata path,
+                                charlie.address, //address to,
+                                timeUntil //uint deadline   
+
+                        );
+                        let charlieBalanceAfterPanic = await mainInstance.balanceOf(charlie.address);
+                        let charlieBalanceReservedAfterPanic = await erc20ReservedToken.balanceOf(charlie.address);
+                        let rc = await tx.wait(); // 0ms, as tx is already confirmed
+                        // let event = rc.events.find(event => event.event === 'PanicSellRateExceeded');
+                        // console.log(rc.events);
+
+                        // here fast and stupid way to find event PanicSellRateExceeded that cann't decoded if happens in external contract
+                        let arr2compare = [
+                            ethers.utils.id("PanicSellRateExceeded(address,address,uint256)"), // keccak256
+                            '0x'+(charlie.address.replace('0x','')).padStart(64, '0'),
+                            '0x'+(uniswapV2Pair.replace('0x','')).padStart(64, '0')
+                        ]
+                        let event = rc.events.find(event => JSON.stringify(JSON.stringify(event.topics)).toLowerCase() === JSON.stringify(JSON.stringify(arr2compare)).toLowerCase());
+                        let eventExists = (typeof(event) !== 'undefined') ? true : false;
+                        expect(eventExists).to.be.eq(true);
+                        if (eventExists) {
+                            // address: '0x2d13826359803522cCe7a4Cfa2c1b582303DD0B4',
+                            // topics: [
+                            //     '0xda8c6cfc61f9766da27a11e69038df366444016f44f525a2907f393407bfc6c3',
+                            //     '0x00000000000000000000000090f79bf6eb2c4f870365e785982e1f101e93b906',
+                            //     '0x0000000000000000000000009b7889734ac75060202410362212d365e9ee1ef5'
+                            // ],
+                            expect(event.address).to.be.eq(mainInstance.address);
+                            expect(ethers.utils.getAddress( event.topics[1].replace('000000000000000000000000','') )).to.be.eq(charlie.address);
+                            expect(ethers.utils.getAddress( event.topics[2].replace('000000000000000000000000','') )).to.be.eq(uniswapV2Pair);
+
+                            // we will adjust value in panic situation from amount to 5
+                            // so transaction didn't revert but emitted event "PanicSellRateExceeded"
+
+                            expect(charlieBalanceBeforePanic.sub(5)).to.be.eq(charlieBalanceAfterPanic);
+                            expect(charlieBalanceReservedBeforePanic.add(4)).to.be.eq(charlieBalanceReservedAfterPanic);
+                        }
+                        //----------------------
+                    
+                    }); 
 
 
                     it("shouldnt add liquidity", async() => {

--- a/test/test.js
+++ b/test/test.js
@@ -473,11 +473,11 @@ describe("TradedTokenInstance", function () {
                 }); 
 
                 it("shouldt setup buyTax value more then buyTaxMax", async() => {
-                    await expect(mainInstance.setBuyTax(maxBuyTax.add(ONE))).to.be.revertedWith(`TaxCanNotBeMoreThen(${maxBuyTax})`);
+                    await expect(mainInstance.setBuyTax(maxBuyTax.add(ONE))).to.be.revertedWith(`TaxCanNotBeMoreThan(${maxBuyTax})`);
                 }); 
 
                 it("shouldt setup sellTax value more then sellTaxMax", async() => {
-                    await expect(mainInstance.setSellTax(maxSellTax.add(ONE))).to.be.revertedWith(`TaxCanNotBeMoreThen(${maxSellTax})`);
+                    await expect(mainInstance.setSellTax(maxSellTax.add(ONE))).to.be.revertedWith(`TaxCanNotBeMoreThan(${maxSellTax})`);
                 }); 
                 
                 it("should setup sellTax", async() => {


### PR DESCRIPTION
was implemented AntiPanic(antiDump feature) with some changes
- we will not reverted transaction if excedeed rate limit. Intead of we emitted event [`PanicSellRateExceeded`](https://github.com/Intercoin/TradedTokenContract/blob/fc0a10c4545c73bb36c575188f0bef7c06fd22f0/contracts/TradedToken.sol#L156) but amount of transferred tokens will reducing to small value (5 wei).
we do this because transaction of for example uniswap does not emit event in our contract when swapping  and emit just "TRANSFER FROM FAILED".  so user will not confirmed thaе limit exceeded